### PR TITLE
Remove the name from the GenServer.

### DIFF
--- a/lib/batch_elixir/stats/statix.ex
+++ b/lib/batch_elixir/stats/statix.ex
@@ -3,7 +3,7 @@ defmodule BatchElixir.Stats.Statix do
   use GenServer
 
   def start_link do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    GenServer.start_link(__MODULE__, :ok)
   end
 
   def init(:ok) do

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BatchElixir.MixProject do
         retry_interval_in_milliseconds: 1_000,
         max_attempts: 3
       ],
-      applications: [:httpoison, :statix],
+      applications: [:httpoison, :statix, :gen_stage],
       extra_applications: [:logger]
     ] ++ mod_application(Mix.env())
   end


### PR DESCRIPTION
The Statix Genserver's name is in conflict with
the Statix connection process.

Add gen_stage in application