### PR TITLE
Stats driver fix bug

### DIFF
--- a/lib/batch_elixir/application.ex
+++ b/lib/batch_elixir/application.ex
@@ -14,6 +14,7 @@ defmodule BatchElixir.Application do
 
   defp _start([]) do
     number_of_consumers = Environment.get(:number_of_consumers)
+    batch_stats_driver = Environment.get(:stats_driver)
 
     consumers =
       for i <- 1..number_of_consumers do
@@ -33,7 +34,7 @@ defmodule BatchElixir.Application do
         },
         %{
           id: BatchElixir.Stats,
-          start: {BatchElixir.Stats, :start_link, []},
+          start: {batch_stats_driver, :start_link, []},
           restart: :permanent
         }
       ] ++ consumers

--- a/lib/batch_elixir/stats.ex
+++ b/lib/batch_elixir/stats.ex
@@ -2,23 +2,13 @@ defmodule BatchElixir.Stats do
   @moduledoc """
   In memory implementation of Queue
   """
-  alias BatchElixir.Environment
-
-  def start_link do
-    stats_driver = get_stats_driver()
-    stats_driver.start_link()
-  end
-
-  defp get_stats_driver do
-    Environment.get(:stats_driver)
-  end
-
+ 
   def increment(key, value \\ 1) do
-    GenServer.cast(get_stats_driver(), {:increment, key, value})
+    GenServer.cast(BatchElixir.Stats, {:increment, key, value})
   end
 
   def timing(key, value) do
-    GenServer.cast(get_stats_driver(), {:timing, key, value})
+    GenServer.cast(BatchElixir.Stats, {:timing, key, value})
   end
 
   def measure(key, func) when is_function(func, 0) do
@@ -28,6 +18,6 @@ defmodule BatchElixir.Stats do
   end
 
   def dump() do
-    GenServer.call(get_stats_driver(), :dump)
+    GenServer.call(BatchElixir.Stats, :dump)
   end
 end

--- a/lib/batch_elixir/stats/memory.ex
+++ b/lib/batch_elixir/stats/memory.ex
@@ -2,7 +2,7 @@ defmodule BatchElixir.Stats.Memory do
   use GenServer
 
   def start_link do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    GenServer.start_link(__MODULE__, :ok, name: BatchElixir.Stats)
   end
 
   def init(:ok) do

--- a/lib/batch_elixir/stats/statix.ex
+++ b/lib/batch_elixir/stats/statix.ex
@@ -3,7 +3,7 @@ defmodule BatchElixir.Stats.Statix do
   use GenServer
 
   def start_link do
-    GenServer.start_link(__MODULE__, :ok)
+    GenServer.start_link(__MODULE__, :ok, name: BatchElixir.Stats)
   end
 
   def init(:ok) do

--- a/test/batch_elixir/server/consumer_test.exs
+++ b/test/batch_elixir/server/consumer_test.exs
@@ -20,7 +20,7 @@ defmodule BatchElixir.Server.ConsurmerTest do
   alias BatchElixir.RestClient.Transactional.Recipients
   alias BatchElixir.Server.Consumer
   alias BatchElixir.Server.Producer
-  alias BatchElixir.Stats
+  alias BatchElixir.Stats.Memory
   use ExUnit.Case
   import Mock
 
@@ -36,7 +36,7 @@ defmodule BatchElixir.Server.ConsurmerTest do
   end
 
   setup do
-    assert {:ok, stat} = Stats.start_link()
+    assert {:ok, stat} = Memory.start_link()
 
     on_exit(fn ->
       assert_down(stat)


### PR DESCRIPTION
# For all stats driver use the same name.

The application start directly the stat driver
instead of BatchElixir.stats module